### PR TITLE
Fixed error from deprecated XML object

### DIFF
--- a/tmx.py
+++ b/tmx.py
@@ -78,7 +78,7 @@ class Tileset(object):
 
 		tileset = cls(name, tile_width, tile_height, firstgid)
 
-		for c in tag.getchildren():
+		for c in tag:
 			if c.tag == "image":
 				# create a tileset
 				tileset.add_image(c.attrib['source'])


### PR DESCRIPTION
[https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren](url)

getchildren()
Deprecated since version 3.2, will be removed in version 3.9: Use list(elem) or iteration.